### PR TITLE
Added extra step to README - how to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Before running this tool make sure:
 
 ## How to use
 ```
+$ docker-compose build --no-cache
 $ docker-compose up
 ```
 


### PR DESCRIPTION
Docker seems to cache previous builds of the Dockerfile.template file. I noticed that when I tried `OS_VERSION=2.83.1_rev8 docker-compose up`, it would end up still using the OS_VERSION from my previous run. It was not until I ran ` OS_VERSION=2.83.1_rev8 docker-compose build --no-cache` did I begin being able to use the updated os version.


