### PR TITLE
update network_mode from bridget to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - /sys/fs/cgroup/systemd
     # this is required for the dns option to have any effect
     # see https://github.com/docker/compose/issues/2847#issuecomment-658999887
-    network_mode: bridge
+    network_mode: host
     dns:
       - 127.0.0.2
     tty: true


### PR DESCRIPTION
With bridget network_mode, the following sudo nmap -p 554 -sT 10.0.0.98 won't be able to get mac address of ip camera. 