### PR TITLE
enforce docker v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Before running this tool make sure:
 
 ```bash
 docker-compose up --build
+docker-compose up --build --detach to run the container in detach mode
 ```
 
 This assumes you have a `config.json` in the project directory. It can be downloaded from your balenaCloud dashboard. Once you have added an application click "Add a new device", click to expand the "Advanced" section and check "Download configuration file only" now click "Download configuration file".

--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ Check out https://github.com/dbhi/qus/#setup for how to set that up.
 ## Development
 
 Want to contribute? Great! Throw pull requests at us.
+
+
+## Configure your device to enable BalenaOS automatically restart after reboot.
+1. sudo systemctl enable docker.service
+2. sudo systemctl enable containerd.service
+See more details [here](https://docs.docker.com/engine/install/linux-postinstall/#configure-docker-to-start-on-boot-with-systemd)

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ Before running this tool make sure:
 4. The balenaOS image is compatible with the architecture where you are running the script. e.g. If you are running this script on your laptop (x86_64), you can run balenaOS images built for the NUC which are also x86_64. [***](#running-other-architectures)
 5. `balenaos-in-container` does not support [`cgroups v2`](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html) yet. Check the version of `cgroups` of your machine. [Guides for Linux users](https://unix.stackexchange.com/questions/619681/how-can-i-find-out-what-version-of-cgroups-i-have), and [Docker Desktop on Mac users](https://docs.docker.com/desktop/mac/release-notes/#bug-fixes-and-minor-changes-1). Downgrade your `cgroups` to v1 if you want to use `balenaos-in-container`.
 
+
 ## How to use
 
+First follow https://docs.docker.com/desktop/install/ubuntu/ to install dockerv2 for ubuntu.
+
 ```bash
-docker-compose up --build
-docker-compose up --build --detach to run the container in detach mode
+docker compose up --build
+docker compose up --build --detach
 ```
 
 This assumes you have a `config.json` in the project directory. It can be downloaded from your balenaCloud dashboard. Once you have added an application click "Add a new device", click to expand the "Advanced" section and check "Download configuration file only" now click "Download configuration file".
@@ -29,10 +32,10 @@ If you need to clear volumes and start with a clean state, use the following com
 
 ```bash
 # bring down all services and remove volumes
-docker-compose down --volumes --remove-orphans
+docker compose down --volumes --remove-orphans
 
 # build and bring up services again with new volumes
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 ## Running other architectures

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - /sys/fs/cgroup/systemd
     # this is required for the dns option to have any effect
     # see https://github.com/docker/compose/issues/2847#issuecomment-658999887
-    network_mode: bridge
+    network_mode: host
     dns:
       - 127.0.0.2
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     dns:
       - 127.0.0.2
     tty: true
+    # see https://stackoverflow.com/questions/43671482/how-to-run-docker-compose-up-d-at-system-start-up for more details
+    restart: always 
 
 volumes:
   boot:


### PR DESCRIPTION
To make the maintenance easier, everyone should use docker compose, not docker-compose. 