### PR TITLE
change registry from docker to bh.cr

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,7 +3,7 @@
 ARG OS_VERSION
 ARG DEVICE_TYPE=%%BALENA_MACHINE_NAME%%
 
-FROM resin/resinos:${OS_VERSION}-${DEVICE_TYPE}
+FROM bh.cr/balena_os/${DEVICE_TYPE}:${OS_VERSION}
 
 COPY ./entry.sh /entry.sh
 COPY ./conf/systemd-watchdog.conf /etc/systemd/system.conf.d/watchdog.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile.template
       args:
-        OS_VERSION: ${OS_VERSION:-2.95.12_rev1}
+        OS_VERSION: ${OS_VERSION:-3.2.4}
         DEVICE_TYPE: ${DEVICE_TYPE:-genericx86-64-ext}
     privileged: true
     stop_signal: SIGRTMIN+3


### PR DESCRIPTION
This will allow to pull + use newer OS images (> 2.95.12)

However as of this moment I haven't been able to get the newer OS images to work on my machine. So leaving at draft for now

Resolves part of https://github.com/balena-os/balenaos-in-container/issues/50

Change-type: patch